### PR TITLE
Proper stop and restart of a fake redis node

### DIFF
--- a/src/fakeredis_cluster.erl
+++ b/src/fakeredis_cluster.erl
@@ -27,10 +27,10 @@
                             EventType    :: connect | command | reply,
                             Data         :: any()}.
 
--record(state, { max_clients = 0
-               , options = []
-               , node_map = #{}
-               , slots_maps = []
+-record(state, { max_clients   = 0   :: non_neg_integer()
+               , options       = []  :: [tuple()]
+               , nodes         = #{} :: #{Id :: binary() | any() => #node{}}
+               , slots_maps    = []  :: [#slots_map{}]
                , ask_redirects = #{} :: #{Key :: binary() => {Host :: binary(),
                                                               Port :: inet:port_number()}}
                , event_log = []      :: [event_log_entry()]
@@ -129,13 +129,13 @@ log_event(EventType, Data) ->
 
 init([Ports, Options, MaxClients]) ->
     ets:new(?STORAGE, [public, set, named_table, {read_concurrency, true}]),
-    {NodeMap, SlotsMaps0} = parse_port_args(Ports),
+    {Nodes, SlotsMaps0} = parse_port_args(Ports),
     SlotsMaps = distribute_slots(SlotsMaps0),
     [fakeredis_instance_sup:start_link(Node#node.port, Options, MaxClients) ||
-        Node <- maps:values(NodeMap)],
+        Node <- maps:values(Nodes)],
     {ok, #state{max_clients = MaxClients,
                 options = Options,
-                node_map = NodeMap,
+                nodes = Nodes,
                 slots_maps = SlotsMaps}}.
 
 handle_cast({log_event, Event}, #state{event_log = Log} = State) ->
@@ -162,7 +162,7 @@ handle_call({get_redirect_by_key, Key}, _From, State) ->
         #{Key := Id} ->
             %% ASK redirect exists for this key
             #node{address = Addr,
-                  port    = Port} = maps:get(Id, State#state.node_map),
+                  port    = Port} = maps:get(Id, State#state.nodes),
             {reply, {ask, Slot, Addr, Port}, State};
         _NoAskRedirect ->
             %% Use cluster slots map
@@ -184,7 +184,7 @@ handle_call({set_ask_redirect, Key, Addr, Port}, _From, State) ->
               port    = Port} ->
             {reply, {error, target_same_as_source}, State};
         _SourceNode ->
-            Nodes = maps:values(State#state.node_map),
+            Nodes = maps:values(State#state.nodes),
             case [Id || #node{address   = Addr0,
                               port      = Port0,
                               id        = Id} <- Nodes,
@@ -223,12 +223,12 @@ code_change(_OldVersion, Tab, _Extra) -> {ok, Tab}.
 %% [M1, M2, M3]
 %% [{M1, S1}, {M2, S2}]
 %% [{M1, S1, S2}, {M2, S3, S4}]
-%% -> {NodeMap, SlotsMaps}
+%% -> {Nodes, SlotsMaps}
 parse_port_args(ArgList) when is_list(ArgList) ->
     Parse = [parse_slots_maps_and_nodes(PortElem) || PortElem <- ArgList],
-    {NodeMapList, SlotsMaps} = lists:unzip(Parse),
-    NodeMap = maps:from_list(lists:flatten(NodeMapList)),
-    {NodeMap, SlotsMaps}.
+    {NodesList, SlotsMaps} = lists:unzip(Parse),
+    Nodes = maps:from_list(lists:flatten(NodesList)),
+    {Nodes, SlotsMaps}.
 
 parse_slots_maps_and_nodes(PortElem) ->
     Nodes = parse_nodes(PortElem),
@@ -240,11 +240,11 @@ parse_nodes(PortElem) when is_tuple(PortElem) ->
     PortList = [element(Pos, PortElem) || Pos <- lists:seq(1, tuple_size(PortElem))],
     {[MasterPort], Replicas} = lists:split(1, PortList),
     lists:flatten([create_node(MasterPort),
-     [create_node(Port) || Port <- Replicas]]);
+                   [create_node(Port) || Port <- Replicas]]);
 parse_nodes(PortElem) when is_list(PortElem) ->
     {[MasterPort], Relicas} = lists:split(1, PortElem),
     lists:flatten([create_node(MasterPort),
-     [create_node(Port) || Port <- Relicas]]);
+                   [create_node(Port) || Port <- Relicas]]);
 parse_nodes(PortElem) ->
     create_node(PortElem).
 
@@ -277,36 +277,36 @@ update_slots([H | T], First, SlotsPerNode, Cursor) ->
 generate_id() ->
     Bits160 = crypto:hash(sha, binary_to_list(crypto:strong_rand_bytes(20))),
     list_to_binary([io_lib:format("~2.16.0b", [X]) ||
-                      X <- binary_to_list(Bits160)]).
+                       X <- binary_to_list(Bits160)]).
 
 create_cluster_slots_resp(State) ->
     [[SlotsMap#slots_map.start_slot,
       SlotsMap#slots_map.end_slot,
       get_cluster_nodes(SlotsMap,
-                        State#state.node_map,
+                        State#state.nodes,
                         SlotsMap#slots_map.slave_ids)] || SlotsMap <- State#state.slots_maps].
 
-get_cluster_nodes(SlotsMap, NodeMap, undefined) ->
-    Master = maps:get(SlotsMap#slots_map.master_id, NodeMap),
+get_cluster_nodes(SlotsMap, Nodes, undefined) ->
+    Master = maps:get(SlotsMap#slots_map.master_id, Nodes),
     [Master#node.address,
-      Master#node.port,
-      Master#node.id];
-get_cluster_nodes(SlotsMap, NodeMap, SlaveIds) ->
-    Master = maps:get(SlotsMap#slots_map.master_id, NodeMap),
-    Replicas = [maps:get(NodeId, NodeMap) || NodeId <- SlaveIds],
+     Master#node.port,
+     Master#node.id];
+get_cluster_nodes(SlotsMap, Nodes, SlaveIds) ->
+    Master = maps:get(SlotsMap#slots_map.master_id, Nodes),
+    Replicas = [maps:get(NodeId, Nodes) || NodeId <- SlaveIds],
     [[Node#node.address,
       Node#node.port,
       Node#node.id] || Node <- [Master] ++ Replicas].
 
 -spec lookup_slot(Slot :: 0..16383, #state{}) -> #node{}.
 lookup_slot(Slot, #state{slots_maps = SlotsMaps,
-                         node_map   = NodeMap}) ->
+                         nodes      = Nodes}) ->
     [Id] = [MasterId || #slots_map{start_slot = Start,
                                    end_slot   = End,
                                    master_id  = MasterId} <- SlotsMaps,
                         Start =< Slot,
                         Slot =< End],
-    maps:get(Id, NodeMap).
+    maps:get(Id, Nodes).
 
 %% Shifts the master and slave ids so that each slot range will have
 %% the master and slaves of the next range in a list of #slots_maps{}.

--- a/src/fakeredis_common.hrl
+++ b/src/fakeredis_common.hrl
@@ -34,5 +34,5 @@
 -record(slots_map, { start_slot = 0 :: integer()
                    , end_slot   = 0 :: integer()
                    , master_id      :: binary()
-                   , slave_ids      :: [binary()] | undefined
+                   , replica_ids    :: [binary()] | undefined
                    }).

--- a/test/fakeredis_cluster_SUITE.erl
+++ b/test/fakeredis_cluster_SUITE.erl
@@ -49,18 +49,34 @@ t_cluster_slots(Config) when is_list(Config) ->
     ok = gen_tcp:send(Sock, Data),
     {ok, _Data} = gen_tcp:recv(Sock, 0),
 
-    %% Kill FakeRedis instance
-    fakeredis_cluster:kill_instance(30001),
+    %% Kill a fake Redis node
+    fakeredis_cluster:kill_node(30001),
     ?assertMatch(ok, gen_tcp:send(Sock, Data)),
     ?assertMatch({error, closed}, gen_tcp:recv(Sock, 0)),
 
-    %% Restart instance
-    fakeredis_cluster:start_instance(30001),
+    %% Need to wait some time after kill_node/1 to be able
+    %% to restart node and setup new server socket
+    timer:sleep(100),
+
+    %% Restart the node again
+    fakeredis_cluster:restart_node(30001),
     {ok, Sock2} = gen_tcp:connect("localhost", 30001,
                                  [binary, {active , false}, {packet, 0}]),
     ok = gen_tcp:send(Sock2, Data),
     {ok, _Data} = gen_tcp:recv(Sock2, 0),
-    ok = gen_tcp:close(Sock2),
+
+    %% Stop a fake Redis node
+    fakeredis_cluster:stop_node(30001),
+    ?assertMatch(ok, gen_tcp:send(Sock2, Data)),
+    ?assertMatch({error, closed}, gen_tcp:recv(Sock2, 0)),
+
+    %% Restart the node again
+    fakeredis_cluster:restart_node(30001),
+    {ok, Sock3} = gen_tcp:connect("localhost", 30001,
+                                 [binary, {active , false}, {packet, 0}]),
+    ok = gen_tcp:send(Sock3, Data),
+    {ok, _Data} = gen_tcp:recv(Sock3, 0),
+    ok = gen_tcp:close(Sock3),
 
     %% Check event log, mostly to check that the event log functionality works.
     timer:sleep(100),
@@ -70,7 +86,10 @@ t_cluster_slots(Config) when is_list(Config) ->
                   {Connection2, connect, _},
                   {Connection2, command, [<<"cluster">>, <<"slots">>]},
                   {Connection2, reply, _},
-                  {Connection2, disconnect, normal}
+                  {Connection3, connect, _},
+                  {Connection3, command, [<<"cluster">>, <<"slots">>]},
+                  {Connection3, reply, _},
+                  {Connection3, disconnect, normal}
                  ],
                  fakeredis_cluster:get_event_log()),
     ok = fakeredis_cluster:clear_event_log(),


### PR DESCRIPTION
Instead of stopping a single connection we now stop a complete fake node, all its connections including the listening socket.

Also change some naming to match the nomenclature in Redis, like using "replica" instead of "slave".